### PR TITLE
Use pull_request for formatting workflow

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -10,7 +10,7 @@ on:
     types: [opened, edited]
   discussion:
     types: [created]
-  pull_request_target:
+  pull_request:
     types: [opened, closed, synchronize, review_requested]
 
 permissions:


### PR DESCRIPTION
## Summary

Use the standard `pull_request` event for the formatting workflow instead of `pull_request_target`.

External fork formatting remains handled by the Ultralytics GitHub App without exposing base-repository secrets to fork code.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

🔒 Updates the formatting workflow to run on standard pull request events instead of privileged pull request triggers.

### 📊 Key Changes

- Replaces `pull_request_target` with `pull_request` in `.github/workflows/format.yml`.
- Keeps the same pull request event types: opened, closed, synchronized, and review requested.
- Limits workflow execution to the pull request’s own context rather than the target repository context.

### 🎯 Purpose & Impact

- 🛡️ Improves workflow security by avoiding elevated `pull_request_target` execution for pull request code.
- ✅ Allows formatting checks to run against the submitted pull request changes.
- ⚙️ May affect workflows that require access to repository secrets or write permissions, since standard pull request workflows have more restricted permissions.