### PR TITLE
Standardize .github configuration

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,0 +1,62 @@
+# Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
+
+name: 🐛 Bug Report
+description: Report an error in the Ultralytics YOLOv8 README, links, or citation
+labels: [bug, triage]
+type: bug
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thank you for submitting an Ultralytics YOLOv8 🐛 Bug Report!
+
+        This repository is the discovery and quickstart page for Ultralytics YOLOv8: README, translated README, license, and citation only. For bugs in the `ultralytics` Python package or `yolo` CLI, please use the [Ultralytics repository](https://github.com/ultralytics/ultralytics/issues).
+
+  - type: checkboxes
+    attributes:
+      label: Search before asking
+      description: >
+        Please search the [YOLOv8 docs](https://docs.ultralytics.com/models/yolov8) and [issues](https://github.com/ultralytics/yolov8/issues) to see if a similar bug report already exists.
+      options:
+        - label: >
+            I have searched the Ultralytics [issues](https://github.com/ultralytics/yolov8/issues) and found no similar bug report.
+          required: true
+
+  - type: dropdown
+    attributes:
+      label: Component
+      description: |
+        Please select the part of the repository where you found the problem.
+      multiple: true
+      options:
+        - "README"
+        - "Translated README"
+        - "Links"
+        - "Model weights"
+        - "Citation"
+        - "Other"
+    validations:
+      required: false
+
+  - type: textarea
+    attributes:
+      label: Bug
+      description: Please describe the problem and where it appears. Quote the incorrect text or link and, if relevant, what it should say. Use [Markdown](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax) to format text and links.
+      placeholder: |
+        💡 ProTip! Link the exact line or section of the README so we can fix it quickly.
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Additional
+      description: Anything else you would like to share?
+
+  - type: checkboxes
+    attributes:
+      label: Are you willing to submit a PR?
+      description: >
+        (Optional) We encourage you to submit a [Pull Request](https://github.com/ultralytics/yolov8/pulls) (PR) to help improve Ultralytics software for everyone, especially if you have a good understanding of how to implement a fix or feature.
+        See the Ultralytics [Contributing Guide](https://docs.ultralytics.com/help/contributing) to get started.
+      options:
+        - label: Yes I'd like to help by submitting a PR!

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,19 @@
+# Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
+
+blank_issues_enabled: true
+contact_links:
+  - name: 📄 YOLOv8 Documentation
+    url: https://docs.ultralytics.com/models/yolov8
+    about: Model overview, benchmarks, and usage examples for Ultralytics YOLOv8
+  - name: 🐛 Ultralytics Package Issues
+    url: https://github.com/ultralytics/ultralytics/issues
+    about: Report bugs in the ultralytics Python package or yolo CLI
+  - name: 💬 Forum
+    url: https://community.ultralytics.com/
+    about: Ask on Ultralytics Community Forum
+  - name: 🎧 Discord
+    url: https://ultralytics.com/discord
+    about: Ask on Ultralytics Discord
+  - name: ⌨️ Reddit
+    url: https://reddit.com/r/ultralytics
+    about: Ask on Ultralytics Subreddit

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -1,0 +1,54 @@
+# Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
+
+name: 🚀 Feature Request
+description: Suggest an improvement to the Ultralytics YOLOv8 README
+labels: [enhancement]
+type: feature
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thank you for submitting an Ultralytics YOLOv8 🚀 Feature Request!
+
+        This repository is the discovery and quickstart page for Ultralytics YOLOv8: README, translated README, license, and citation only. For bugs in the `ultralytics` Python package or `yolo` CLI, please use the [Ultralytics repository](https://github.com/ultralytics/ultralytics/issues).
+
+  - type: checkboxes
+    attributes:
+      label: Search before asking
+      description: >
+        Please search the [YOLOv8 docs](https://docs.ultralytics.com/models/yolov8) and [issues](https://github.com/ultralytics/yolov8/issues) to see if a similar feature request already exists.
+      options:
+        - label: >
+            I have searched the Ultralytics [issues](https://github.com/ultralytics/yolov8/issues) and found no similar feature requests.
+          required: true
+
+  - type: textarea
+    attributes:
+      label: Description
+      description: A short description of your feature.
+      placeholder: |
+        What would you like to see added or changed in the YOLOv8 README?
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Use case
+      description: |
+        Describe the use case of your feature request. It will help us understand and prioritize the feature request.
+      placeholder: |
+        How would this help people discovering YOLOv8?
+
+  - type: textarea
+    attributes:
+      label: Additional
+      description: Anything else you would like to share?
+
+  - type: checkboxes
+    attributes:
+      label: Are you willing to submit a PR?
+      description: >
+        (Optional) We encourage you to submit a [Pull Request](https://github.com/ultralytics/yolov8/pulls) (PR) to help improve Ultralytics software for everyone, especially if you have a good understanding of how to implement a fix or feature.
+        See the Ultralytics [Contributing Guide](https://docs.ultralytics.com/help/contributing) to get started.
+      options:
+        - label: Yes I'd like to help by submitting a PR!

--- a/.github/ISSUE_TEMPLATE/question.yml
+++ b/.github/ISSUE_TEMPLATE/question.yml
@@ -1,0 +1,36 @@
+# Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
+
+name: ❓ Question
+description: Ask an Ultralytics YOLOv8 question
+labels: [question]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thank you for asking an Ultralytics YOLOv8 ❓ Question!
+
+        This repository is the discovery and quickstart page for Ultralytics YOLOv8: README, translated README, license, and citation only. For bugs in the `ultralytics` Python package or `yolo` CLI, please use the [Ultralytics repository](https://github.com/ultralytics/ultralytics/issues).
+
+  - type: checkboxes
+    attributes:
+      label: Search before asking
+      description: >
+        Please search the [YOLOv8 docs](https://docs.ultralytics.com/models/yolov8), [issues](https://github.com/ultralytics/yolov8/issues) and [discussions](https://github.com/orgs/ultralytics/discussions) to see if a similar question already exists.
+      options:
+        - label: >
+            I have searched the Ultralytics [issues](https://github.com/ultralytics/yolov8/issues) and [discussions](https://github.com/orgs/ultralytics/discussions) and found no similar questions.
+          required: true
+
+  - type: textarea
+    attributes:
+      label: Question
+      description: What is your question? Please provide as much information as possible. Format your text and code using [Markdown](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax) for clarity and readability.
+      placeholder: |
+        💡 ProTip! Include as much information as possible (links, screenshots etc.) to receive the most helpful response.
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Additional
+      description: Anything else you would like to share?

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -28,7 +28,7 @@ jobs:
           labels: true # Auto-label issues/PRs using AI
           prettier: true # Format YAML, JSON, Markdown, CSS
           spelling: true # Check spelling with codespell
-          links: false # Check broken links with Lychee
+          links: true # Check broken links with Lychee
           summary: true # Generate AI-powered PR summaries
           openai_api_key: ${{ secrets.OPENAI_API_KEY }} # Powers PR summaries, labels and comments
           brave_api_key: ${{ secrets.BRAVE_API_KEY }} # Used for broken link resolution


### PR DESCRIPTION
Enable the Lychee link check in format.yml. This repository is README-only, so broken links are its only failure mode; matches the current Ultralytics repository standard.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Standardizes repository configuration by adding structured issue forms and enabling Lychee link checks for the README-focused repository.

### 📊 Key Changes

- Added bug report, feature request, and question issue forms with repository-specific prompts, labels, and routing guidance.
- Added issue configuration with links to YOLOv8 documentation, Ultralytics package issues, the community forum, Discord, and Reddit.
- Enabled Lychee broken-link checking in `.github/workflows/format.yml`.

### 🎯 Purpose & Impact

- Contributors now receive structured forms for reporting README, translation, link, model weight, citation, and usage issues.
- GitHub issue configuration directs package and CLI problems to the main Ultralytics repository and provides alternative support channels.
- The format workflow now checks repository links, making broken links a detectable validation failure.