### PR TITLE
Remove trailing slashes and update redirected Ultralytics URLs

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -9,7 +9,7 @@ contact_links:
     url: https://github.com/ultralytics/ultralytics/issues
     about: Report bugs in the ultralytics Python package or yolo CLI
   - name: 💬 Forum
-    url: https://community.ultralytics.com/
+    url: https://community.ultralytics.com
     about: Ask on Ultralytics Community Forum
   - name: 🎧 Discord
     url: https://ultralytics.com/discord

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
     <a href="https://github.com/ultralytics/ultralytics/actions/workflows/ci.yml"><img src="https://github.com/ultralytics/ultralytics/actions/workflows/ci.yml/badge.svg" alt="Ultralytics CI"></a>
     <a href="https://clickpy.clickhouse.com/dashboard/ultralytics"><img src="https://static.pepy.tech/badge/ultralytics" alt="Ultralytics Downloads"></a>
     <a href="https://discord.com/invite/ultralytics"><img alt="Ultralytics Discord" src="https://img.shields.io/discord/1089800235347353640?logo=discord&logoColor=white&label=Discord&color=blue"></a>
-    <a href="https://community.ultralytics.com/"><img alt="Ultralytics Forums" src="https://img.shields.io/discourse/users?server=https%3A%2F%2Fcommunity.ultralytics.com&logo=discourse&label=Forums&color=blue"></a>
+    <a href="https://community.ultralytics.com"><img alt="Ultralytics Forums" src="https://img.shields.io/discourse/users?server=https%3A%2F%2Fcommunity.ultralytics.com&logo=discourse&label=Forums&color=blue"></a>
     <a href="https://www.reddit.com/r/ultralytics/"><img alt="Ultralytics Reddit" src="https://img.shields.io/reddit/subreddit-subscribers/ultralytics?style=flat&logo=reddit&logoColor=white&label=Reddit&color=blue"></a>
     <br>
     <a href="https://console.paperspace.com/github/ultralytics/ultralytics"><img src="https://assets.paperspace.io/img/gradient-badge.svg" alt="Run Ultralytics on Gradient"></a>
@@ -20,7 +20,7 @@
 </div>
 <br>
 
-[Ultralytics](https://www.ultralytics.com/) [YOLOv8](https://docs.ultralytics.com/models/yolov8) is available
+[Ultralytics](https://www.ultralytics.com) [YOLOv8](https://docs.ultralytics.com/models/yolov8) is available
 through the official [Ultralytics YOLO](https://github.com/ultralytics/ultralytics) package. It supports object
 detection, instance segmentation, image classification, pose estimation, oriented object detection, and tracking in a
 fast, accurate, and easy to use Python and CLI workflow.
@@ -151,7 +151,7 @@ or upgrade the [Ultralytics Python package](https://pypi.org/project/ultralytics
 
 For questions, discussions, and community support, join our active communities on
 [Discord](https://discord.com/invite/ultralytics), [Reddit](https://www.reddit.com/r/ultralytics/), and the
-[Ultralytics Community Forums](https://community.ultralytics.com/).
+[Ultralytics Community Forums](https://community.ultralytics.com).
 
 <br>
 <div align="center">

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -10,7 +10,7 @@
     <a href="https://github.com/ultralytics/ultralytics/actions/workflows/ci.yml"><img src="https://github.com/ultralytics/ultralytics/actions/workflows/ci.yml/badge.svg" alt="Ultralytics CI"></a>
     <a href="https://clickpy.clickhouse.com/dashboard/ultralytics"><img src="https://static.pepy.tech/badge/ultralytics" alt="Ultralytics Downloads"></a>
     <a href="https://discord.com/invite/ultralytics"><img alt="Ultralytics Discord" src="https://img.shields.io/discord/1089800235347353640?logo=discord&logoColor=white&label=Discord&color=blue"></a>
-    <a href="https://community.ultralytics.com/"><img alt="Ultralytics Forums" src="https://img.shields.io/discourse/users?server=https%3A%2F%2Fcommunity.ultralytics.com&logo=discourse&label=Forums&color=blue"></a>
+    <a href="https://community.ultralytics.com"><img alt="Ultralytics Forums" src="https://img.shields.io/discourse/users?server=https%3A%2F%2Fcommunity.ultralytics.com&logo=discourse&label=Forums&color=blue"></a>
     <a href="https://www.reddit.com/r/ultralytics/"><img alt="Ultralytics Reddit" src="https://img.shields.io/reddit/subreddit-subscribers/ultralytics?style=flat&logo=reddit&logoColor=white&label=Reddit&color=blue"></a>
     <br>
     <a href="https://console.paperspace.com/github/ultralytics/ultralytics"><img src="https://assets.paperspace.io/img/gradient-badge.svg" alt="Run Ultralytics on Gradient"></a>
@@ -20,7 +20,7 @@
 </div>
 <br>
 
-[Ultralytics](https://www.ultralytics.com/) [YOLOv8](https://docs.ultralytics.com/zh/models/yolov8) 可通过官方
+[Ultralytics](https://www.ultralytics.com) [YOLOv8](https://docs.ultralytics.com/zh/models/yolov8) 可通过官方
 [Ultralytics YOLO](https://github.com/ultralytics/ultralytics) 包使用，支持目标检测、实例分割、图像分类、姿态估计、旋转目标检测和跟踪，并提供快速、准确、易用的 Python 与 CLI 工作流。
 
 本仓库是 YOLOv8 的轻量级发现入口。官方实现、软件包发布、模型下载、Issues 和 Pull Requests 均在
@@ -127,7 +127,7 @@ YOLOv8 使用指南请先查看 [YOLOv8 文档](https://docs.ultralytics.com/zh/
 > 提交错误报告和功能请求，方便维护者结合源代码统一分类处理。
 
 如有疑问、讨论和社区支持，请加入 [Discord](https://discord.com/invite/ultralytics)、[Reddit](https://www.reddit.com/r/ultralytics/)
-和 [Ultralytics 社区论坛](https://community.ultralytics.com/)。
+和 [Ultralytics 社区论坛](https://community.ultralytics.com)。
 
 <br>
 <div align="center">


### PR DESCRIPTION
Canonicalizes Ultralytics link targets in this discovery repo so every `ultralytics.com` URL is slash-free, and re-checks all outbound links against their live redirect destinations.

## Trailing slashes (7 removed, 3 files)

| File | Fixes |
| --- | --- |
| `README.md` | 3 (`www.ultralytics.com/`, two `community.ultralytics.com/`) |
| `README.zh-CN.md` | 3 (same three links, mirrored per AGENTS.md) |
| `.github/ISSUE_TEMPLATE/config.yml` | 1 (`community.ultralytics.com/` forum contact link) |

Only path-terminating slashes were removed — path separators, non-Ultralytics hosts (`github.com/ultralytics/...`, `reddit.com/r/ultralytics/`, `pypi.org/project/ultralytics/`, `linkedin.com/company/ultralytics/`) and the URL-encoded shields.io badge parameter `server=https%3A%2F%2Fcommunity.ultralytics.com` are untouched. Verification confirms zero remaining terminating slashes on `ultralytics.com` or any subdomain.

## Redirect refresh (0 applied)

All 88 unique outbound links were resolved. Four redirect to a different final URL, and all four were rejected as unsafe to bake in:

- `github.com/ultralytics/ultralytics/issues/new/choose` -> `github.com/login?return_to=...` — auth handshake for logged-out visitors; the deep link is correct for logged-in users.
- `youtube.com/ultralytics?sub_confirmation=1` -> `consent.youtube.com/m?...&gl=ES` — geo-specific consent wall, not a content move.
- `ultralytics.com/bilibili` -> `space.bilibili.com/...` — vanity shortlink intended to stay a redirect.
- `twitter.com/ultralytics` -> `x.com/ultralytics` — a genuine brand move, but this social footer block is kept byte-identical across Ultralytics repos and `ultralytics/ultralytics` still uses `twitter.com`; changing it here alone would desync the footer, so it is left for an org-wide sweep.

No dead links were found: every other link resolves 200 to itself. `clickpy.clickhouse.com/dashboard/ultralytics` returns 403 to automated clients (bot blocking, loads fine in a browser) and was left as-is.

## Validation

- All 6 YAML files plus `CITATION.cff` parse cleanly.
- `prettier@3.8.5 --print-width 120 --check` passes on all Markdown and YAML.
- Diff is URL text only; no prose, structure, or workflow changes.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Canonicalized seven Ultralytics URLs by removing trailing slashes in the English and Chinese READMEs and issue template configuration, while leaving redirected links unchanged.

### 📊 Key Changes

- Updated three links in `README.md` and the corresponding three links in `README.zh-CN.md` to use slash-free `ultralytics.com` URLs.
- Updated the Ultralytics Community Forum link in `.github/ISSUE_TEMPLATE/config.yml`.
- Preserved non-Ultralytics URLs, URL-encoded badge parameters, and four links whose redirects were considered unsuitable for replacement.
- No prose, document structure, or workflow changes were made.

### 🎯 Purpose & Impact

- Standardizes Ultralytics URL formatting across repository entry points and removes reliance on trailing-slash redirects.
- The four reviewed redirecting links and the browser-accessible but automation-blocked ClickPy dashboard link remain unchanged; no user-facing workflow change is introduced.